### PR TITLE
Add LoggingAspect for service method execution tracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/gem/taskmanager/aspect/LoggingAspect.java
+++ b/src/main/java/com/gem/taskmanager/aspect/LoggingAspect.java
@@ -1,0 +1,30 @@
+package com.gem.taskmanager.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Aspect
+@Component
+public class LoggingAspect
+{
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+    //pointcut
+    @Before("execution(* com.gem.taskmanager.service.*.*(..))")
+    public void logBefore(JoinPoint joinPoint)
+    {
+        logger.info("executing method: {}", joinPoint.getSignature().getName());
+    }
+    // calculus
+
+    @AfterReturning(pointcut = "execution(* com.gem.taskmanager.service.*.*(..))", returning = "result")
+    public void logAfterReturning(JoinPoint joinPoint, Object result) {
+        logger.info("method executed: {}, returned: {}", joinPoint.getSignature().getName(), result);
+    }
+
+
+}

--- a/src/main/java/com/gem/taskmanager/service/TaskService.java
+++ b/src/main/java/com/gem/taskmanager/service/TaskService.java
@@ -24,6 +24,7 @@ public class TaskService
     public Task addTask(Task task, User user)
     {
         task.setUser(user);
+        //logging / ASPECT - AOP
         return taskRepository.save(task);
     }
 


### PR DESCRIPTION
Introduced an AOP-based LoggingAspect to log method execution and results for service layer methods. Updated dependencies in pom.xml to include Spring AOP support. This enhances traceability and debugging within the application.